### PR TITLE
Add ability to pay multiple people

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 pkg/*
 *.gem
 .bundle
+.rvmrc*
+.DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,38 @@
+PATH
+  remote: .
+  specs:
+    paypal-ipn (0.0.2)
+      httparty
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    addressable (2.3.5)
+    crack (0.4.1)
+      safe_yaml (~> 0.9.0)
+    diff-lcs (1.2.5)
+    httparty (0.12.0)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
+    json (1.8.1)
+    multi_xml (0.5.5)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.7)
+    rspec-expectations (2.14.4)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.4)
+    safe_yaml (0.9.7)
+    webmock (1.17.1)
+      addressable (>= 2.2.7)
+      crack (>= 0.3.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  paypal-ipn!
+  rspec
+  webmock

--- a/lib/paypal/ipn/types/masspay.rb
+++ b/lib/paypal/ipn/types/masspay.rb
@@ -1,22 +1,22 @@
 module Paypal
   module Ipn
     module Masspay
-      def payment_status
-        params["status_1"] if params
+      def payment_status(i)
+        params["status_#{i}"] if params
       end
 
       def payment_unclaimed?
         payment_status == "Unclaimed"
       end
 
-      def txn_id
-        params["masspay_txn_id_1"] if params
+      def txn_id(i)
+        params["masspay_txn_id_#{i}"] if params
       end
       alias_method :transaction_id, :txn_id
 
       private
-        def unique_id
-          params["unique_id_1"]
+        def unique_id(i)
+          params["unique_id_#{i}"]
         end
     end
   end

--- a/lib/paypal/masspay.rb
+++ b/lib/paypal/masspay.rb
@@ -18,9 +18,11 @@ module Paypal
       }
       body.merge!("EMAILSUBJECT" => email_subject) if email_subject
       response = ''
+      Rails.logger.info(receiver_email)
       if receiver_email.is_a?(Array)
         max = 250
         new_body = body.dup
+        Rails.logger.info(new_body)
         (receiver_email.length.to_f / max).ceil.times do |group|
           offset = group * max
           receiver_email[offset..(offset + max -1)].each_with_index do |email, i|

--- a/lib/paypal/masspay.rb
+++ b/lib/paypal/masspay.rb
@@ -28,7 +28,7 @@ module Paypal
           receiver_email[offset..(offset + max -1)].each_with_index do |email, i|
             new_body = new_body.merge({
               "L_EMAIL#{i}" => email,
-              "L_AMT#{i}" => amount.is_a?(Array) ? amount[i].to_f : amount.to_f,
+              "L_AMT#{i}" => amount.is_a?(Array) ? amount[i].to_f.to_s : amount.to_f.to_s,
               "L_UNIQUEID#{i}" => "#{unique_id}-#{i}",
               "L_NOTE#{i}" => note})
           end
@@ -38,7 +38,7 @@ module Paypal
       else
         body = body.merge({
           "L_EMAIL0" => receiver_email,
-          "L_AMT0" => amount.to_f,
+          "L_AMT0" => amount.to_f.to_s,
           "L_UNIQUEID0" => unique_id,
           "L_NOTE0" => note})
         response = self.post(request_uri.to_s, :body => body).body

--- a/lib/paypal/masspay.rb
+++ b/lib/paypal/masspay.rb
@@ -84,6 +84,21 @@ module Paypal
     def successful_payment?
       payment_response["ACK"] == "Success"
     end
+    
+    def payment_error_type
+      case payment_response["L_ERRORCODE0"]
+        when "10002" || "10007"
+          :unauthorized
+        when "10321"
+          :insufficient_funds
+        else
+          :unknown
+      end
+    end
+
+    def payment_error_message
+      payment_response["L_LONGMESSAGE0"]
+    end
 
     private
       def masspay(payer_email, receiver_email, amount, currency, note, unique_id, email_subject = '')
@@ -96,21 +111,6 @@ module Paypal
           unique_id,
           email_subject
         )
-      end
-
-      def payment_error_type
-        case payment_response["L_ERRORCODE0"]
-          when "10002" || "10007"
-            :unauthorized
-          when "10321"
-            :insufficient_funds
-          else
-            :unknown
-        end
-      end
-
-      def payment_error_message
-        payment_response["L_LONGMESSAGE0"]
       end
   end
 end

--- a/lib/paypal/masspay.rb
+++ b/lib/paypal/masspay.rb
@@ -30,6 +30,7 @@ module Paypal
               "L_UNIQUEID#{i}" => "#{unique_id}-#{i}",
               "L_NOTE#{i}" => note})
           end
+          Rails.logger.info(new_body)
           response = self.post(request_uri.to_s, :body => new_body).body
         end
       else

--- a/lib/paypal/masspay.rb
+++ b/lib/paypal/masspay.rb
@@ -28,7 +28,7 @@ module Paypal
           receiver_email[offset..(offset + max -1)].each_with_index do |email, i|
             new_body = new_body.merge({
               "L_EMAIL#{i}" => email,
-              "L_AMT#{i}" => amount.is_a?(Array) ? amount[i].to_f.to_s : amount.to_f.to_s,
+              "L_AMT#{i}" => amount.is_a?(Array) ? amount[i] : amount,
               "L_UNIQUEID#{i}" => "#{unique_id}-#{i}",
               "L_NOTE#{i}" => note})
           end
@@ -38,7 +38,7 @@ module Paypal
       else
         body = body.merge({
           "L_EMAIL0" => receiver_email,
-          "L_AMT0" => amount.to_f.to_s,
+          "L_AMT0" => amount,
           "L_UNIQUEID0" => unique_id,
           "L_NOTE0" => note})
         response = self.post(request_uri.to_s, :body => body).body

--- a/lib/paypal/masspay.rb
+++ b/lib/paypal/masspay.rb
@@ -31,8 +31,9 @@ module Paypal
           "L_NOTE#{i}" => payment[:note]
         })
         Rails.logger.info(new_body)
-        response = self.post(request_uri.to_s, :body => new_body).body
       end
+      
+      response = self.post(request_uri.to_s, :body => new_body).body
       
       response
     end

--- a/lib/paypal/masspay.rb
+++ b/lib/paypal/masspay.rb
@@ -2,7 +2,7 @@ module Paypal
   module Masspay
     include HTTParty
 
-    def self.masspay(payer_email, receiver_email, amount, currency, note, unique_id, email_subject = '')
+    def self.masspay(payer_email, receiver_email, amount, currency, note, unique_id, email_subject = nil)
       request_uri = URI.parse(Paypal.nvp_uri)
       request_uri.scheme = "https" # force https
 
@@ -14,9 +14,9 @@ module Paypal
         "USER" => Paypal.api_username,
         "PWD" => Paypal.api_password,
         "SIGNATURE" => Paypal.api_signature,
-        "RECEIVERTYPE" => "EmailAddress",
-        "EMAIL_SUBJECT" => email_subject
+        "RECEIVERTYPE" => "EmailAddress"
       }
+      body.merge!("EMAILSUBJECT" => email_subject) if email_subject
       response = ''
       if receiver_email.is_a?(Array)
         max = 250

--- a/lib/paypal/masspay.rb
+++ b/lib/paypal/masspay.rb
@@ -18,9 +18,11 @@ module Paypal
       }
       body.merge!("EMAILSUBJECT" => email_subject) if email_subject
       response = ''
+      Rails.logger.info(receiver_email)
       if receiver_email.is_a?(Array)
         max = 250
         new_body = body.dup
+        Rails.logger.info(new_body)
         (receiver_email.length.to_f / max).ceil.times do |group|
           offset = group * max
           receiver_email[offset..(offset + max -1)].each_with_index do |email, i|
@@ -30,6 +32,7 @@ module Paypal
               "L_UNIQUEID#{i}" => "#{unique_id}-#{i}",
               "L_NOTE#{i}" => note})
           end
+          Rails.logger.info(new_body)
           response = self.post(request_uri.to_s, :body => new_body).body
         end
       else

--- a/lib/paypal/masspay.rb
+++ b/lib/paypal/masspay.rb
@@ -18,27 +18,24 @@ module Paypal
       }
       body.merge!("EMAILSUBJECT" => email_subject) if email_subject
       response = ''
-      Rails.logger.info(receiver_email)
       if receiver_email.is_a?(Array)
         max = 250
         new_body = body.dup
-        Rails.logger.info(new_body)
         (receiver_email.length.to_f / max).ceil.times do |group|
           offset = group * max
           receiver_email[offset..(offset + max -1)].each_with_index do |email, i|
             new_body = new_body.merge({
               "L_EMAIL#{i}" => email,
-              "L_AMT#{i}" => amount.is_a?(Array) ? amount[i] : amount,
+              "L_AMT#{i}" => amount.is_a?(Array) ? amount[i].to_f : amount.to_f,
               "L_UNIQUEID#{i}" => "#{unique_id}-#{i}",
               "L_NOTE#{i}" => note})
           end
-          Rails.logger.info(new_body)
           response = self.post(request_uri.to_s, :body => new_body).body
         end
       else
         body = body.merge({
           "L_EMAIL0" => receiver_email,
-          "L_AMT0" => amount,
+          "L_AMT0" => amount.to_f,
           "L_UNIQUEID0" => unique_id,
           "L_NOTE0" => note})
         response = self.post(request_uri.to_s, :body => body).body

--- a/lib/paypal/version.rb
+++ b/lib/paypal/version.rb
@@ -1,3 +1,3 @@
 module Paypal
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/lib/paypal/version.rb
+++ b/lib/paypal/version.rb
@@ -1,3 +1,3 @@
 module Paypal
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/paypal-ipn.gemspec
+++ b/paypal-ipn.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/dwilkie/paypal"
   s.summary     = %q{More than just IPNs}
   s.description = %q{A ruby library for handling paypal api's including IPNs}
-  s.add_runtime_dependency("httparty")
 
   s.rubyforge_project = "paypal"
 
@@ -19,5 +18,9 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+  
+  # Gemfile
+  s.add_runtime_dependency("httparty")
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'webmock'
 end
-


### PR DESCRIPTION
Added my own method of paying multiple people. This is done by passing in an array of hashes that contain all the relevant info such as:

[{email: '', amount:''}, {email: '', amount: ''}]

Branched off of twinge's code but preferred my style of mass payment instead of passing parallel arrays.
